### PR TITLE
Fix failing test: Change from Base64 to Hex encoding

### DIFF
--- a/src/main/java/com/teragrep/jai_02/entry/EntryAliasString.java
+++ b/src/main/java/com/teragrep/jai_02/entry/EntryAliasString.java
@@ -45,11 +45,10 @@
  */
 package com.teragrep.jai_02.entry;
 
+import com.teragrep.jai_02.password.DecodedHex;
 import com.teragrep.jai_02.password.Salt;
 import com.teragrep.jai_02.user.UserNameImpl;
 import com.teragrep.jai_02.user.UserNameValid;
-
-import java.util.Base64;
 
 /**
  * Provides facilities to generate an EntryAlias object from
@@ -73,7 +72,7 @@ public class EntryAliasString {
 
         String userName = fragments[0];
         UserNameValid userNameValid = new UserNameValid(new UserNameImpl(userName, split));
-        Salt salt = new Salt(Base64.getDecoder().decode(fragments[1]));
+        Salt salt = new Salt(new DecodedHex(fragments[1]).decode());
 
         int iterationCount;
         try {

--- a/src/main/java/com/teragrep/jai_02/keystore/CachingKeyStoreAccess.java
+++ b/src/main/java/com/teragrep/jai_02/keystore/CachingKeyStoreAccess.java
@@ -80,7 +80,10 @@ public class CachingKeyStoreAccess implements KeyStoreAccess {
             }
         };
 
-        this.loadingCache = CacheBuilder.newBuilder().expireAfterWrite(secs, TimeUnit.SECONDS).build(cacheLoader);
+        this.loadingCache = CacheBuilder
+                .newBuilder()
+                .refreshAfterWrite(secs, TimeUnit.SECONDS)
+                .build(cacheLoader);
 
     }
 
@@ -101,6 +104,11 @@ public class CachingKeyStoreAccess implements KeyStoreAccess {
     }
 
     public int deleteKey(final String usernameToRemove) throws KeyStoreException, IOException {
+        loadingCache.asMap().forEach((k, v) -> {
+           if (k.username().equals(usernameToRemove)) {
+               loadingCache.invalidate(k);
+           }
+        });
         return keyStoreAccess.deleteKey(usernameToRemove);
     }
 

--- a/src/main/java/com/teragrep/jai_02/keystore/CachingKeyStoreAccess.java
+++ b/src/main/java/com/teragrep/jai_02/keystore/CachingKeyStoreAccess.java
@@ -80,7 +80,7 @@ public class CachingKeyStoreAccess implements KeyStoreAccess {
             }
         };
 
-        this.loadingCache = CacheBuilder.newBuilder().refreshAfterWrite(secs, TimeUnit.SECONDS).build(cacheLoader);
+        this.loadingCache = CacheBuilder.newBuilder().expireAfterWrite(secs, TimeUnit.SECONDS).build(cacheLoader);
 
     }
 

--- a/src/main/java/com/teragrep/jai_02/keystore/KeyStoreAccessImpl.java
+++ b/src/main/java/com/teragrep/jai_02/keystore/KeyStoreAccessImpl.java
@@ -54,6 +54,7 @@ import com.teragrep.jai_02.user.UserToAliasMapping;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.*;
@@ -125,7 +126,9 @@ public class KeyStoreAccessImpl implements KeyStoreAccess {
         try {
             keyStore.setEntry(keyWithSecret.asEntryAlias().toString(), new KeyStore.SecretKeyEntry(keyWithSecret.build(password).secretKey()),
                     new KeyStore.PasswordProtection(keyStorePassword));
-            keyStore.store(Files.newOutputStream(Paths.get(keyStorePath)), keyStorePassword);
+            OutputStream outputStream = Files.newOutputStream(Paths.get(keyStorePath));
+            keyStore.store(outputStream, keyStorePassword);
+            outputStream.close();
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("Invalid algorithm provided: ", e);
         } catch (CertificateException e) {
@@ -166,7 +169,9 @@ public class KeyStoreAccessImpl implements KeyStoreAccess {
 
         // commit changes to disk
         try {
-            keyStore.store(Files.newOutputStream(Paths.get(keyStorePath)), keyStorePassword);
+            OutputStream outputStream = Files.newOutputStream(Paths.get(keyStorePath));
+            keyStore.store(outputStream, keyStorePassword);
+            outputStream.close();
         } catch (NoSuchAlgorithmException | CertificateException e) {
             throw new RuntimeException("Error storing keyStore after alias deletion: ", e);
         }

--- a/src/main/java/com/teragrep/jai_02/keystore/KeyStoreFactory.java
+++ b/src/main/java/com/teragrep/jai_02/keystore/KeyStoreFactory.java
@@ -44,7 +44,9 @@ package com.teragrep.jai_02.keystore;/*
  * a licensee so wish it.
  */
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -88,7 +90,9 @@ public class KeyStoreFactory {
             if (Files.notExists(pathToKeyStore, LinkOption.NOFOLLOW_LINKS)) {
                 ks.load(null, null);
             } else {
-                ks.load(Files.newInputStream(pathToKeyStore), pw);
+                InputStream inputStream = Files.newInputStream(pathToKeyStore);
+                ks.load(inputStream, pw);
+                inputStream.close();
             }
 
         } catch (KeyStoreException | NoSuchAlgorithmException e) {

--- a/src/main/java/com/teragrep/jai_02/keystore/ReloadingKeyStoreAccess.java
+++ b/src/main/java/com/teragrep/jai_02/keystore/ReloadingKeyStoreAccess.java
@@ -56,8 +56,7 @@ import java.security.InvalidKeyException;
 import java.security.KeyStoreException;
 import java.security.UnrecoverableEntryException;
 import java.security.spec.InvalidKeySpecException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 public class ReloadingKeyStoreAccess implements KeyStoreAccess {
     private final KeyStoreAccess ksa;
@@ -78,7 +77,7 @@ public class ReloadingKeyStoreAccess implements KeyStoreAccess {
         this.loadingCache = CacheBuilder
                 .newBuilder()
                 .maximumSize(1L)
-                .expireAfterWrite(secs, TimeUnit.SECONDS)
+                .refreshAfterWrite(secs, TimeUnit.SECONDS)
                 .build(cacheLoader);
     }
 

--- a/src/main/java/com/teragrep/jai_02/keystore/ReloadingKeyStoreAccess.java
+++ b/src/main/java/com/teragrep/jai_02/keystore/ReloadingKeyStoreAccess.java
@@ -60,7 +60,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class ReloadingKeyStoreAccess implements KeyStoreAccess {
-    private KeyStoreAccess ksa;
+    private final KeyStoreAccess ksa;
     private final LoadingCache<Long, KeyStoreAccess> loadingCache;
     public ReloadingKeyStoreAccess(KeyStoreAccess ksa, long secs) {
         this.ksa = ksa;
@@ -78,7 +78,7 @@ public class ReloadingKeyStoreAccess implements KeyStoreAccess {
         this.loadingCache = CacheBuilder
                 .newBuilder()
                 .maximumSize(1L)
-                .refreshAfterWrite(secs, TimeUnit.SECONDS)
+                .expireAfterWrite(secs, TimeUnit.SECONDS)
                 .build(cacheLoader);
     }
 

--- a/src/main/java/com/teragrep/jai_02/password/DecodedHex.java
+++ b/src/main/java/com/teragrep/jai_02/password/DecodedHex.java
@@ -43,56 +43,26 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-package com.teragrep.jai_02.keystore;
+package com.teragrep.jai_02.password;
 
-import com.teragrep.jai_02.password.DecodedHex;
-import com.teragrep.jai_02.password.Salt;
-import com.teragrep.jai_02.password.SaltFactory;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import java.math.BigInteger;
 
-import java.util.Base64;
-
-public class SaltTest {
-
-    @Test
-    public void testSaltDefaultLength() {
-        SaltFactory saltFactory = new SaltFactory();
-        Salt salt = saltFactory.createSalt();
-        Assertions.assertEquals(20, salt.asBytes().length);
+public class DecodedHex {
+    private final String hexString;
+    public DecodedHex(String hexString) {
+        this.hexString = hexString;
     }
 
-    @Test
-    public void testSaltCustomLength() {
-        SaltFactory saltFactory = new SaltFactory(42);
-        Salt salt = saltFactory.createSalt();
-        Assertions.assertEquals(42, salt.asBytes().length);
-    }
-
-    @Test
-    public void testSaltHex() {
-        SaltFactory saltFactory = new SaltFactory();
-        Salt salt = saltFactory.createSalt();
-        byte[] saltDecoded = new DecodedHex(salt.toString()).decode();
-        Assertions.assertArrayEquals(salt.asBytes(), saltDecoded);
-    }
-
-    @Test
-    public void testSaltHexString() {
-        SaltFactory saltFactory = new SaltFactory();
-        Salt salt = saltFactory.createSalt();
-        String saltString = salt.toString();
-
-        Salt other = new Salt(new DecodedHex(saltString).decode());
-
-        Assertions.assertEquals(salt, other);
-    }
-
-    @Test
-    public void testSaltNotEqual() {
-        SaltFactory saltFactory = new SaltFactory();
-        Salt salt = saltFactory.createSalt();
-        Salt other = saltFactory.createSalt();
-        Assertions.assertNotEquals(salt, other);
+    public byte[] decode() {
+        byte[] byteArray = new BigInteger(hexString, 16)
+                .toByteArray();
+        if (byteArray[0] == 0) {
+            byte[] output = new byte[byteArray.length - 1];
+            System.arraycopy(
+                    byteArray, 1, output,
+                    0, output.length);
+            return output;
+        }
+        return byteArray;
     }
 }

--- a/src/main/java/com/teragrep/jai_02/password/Salt.java
+++ b/src/main/java/com/teragrep/jai_02/password/Salt.java
@@ -45,9 +45,8 @@
  */
 package com.teragrep.jai_02.password;
 
-import java.nio.charset.StandardCharsets;
+import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Base64;
 
 /**
  * Defines the salt used for salting the SecretKey.
@@ -59,17 +58,14 @@ public class Salt {
         this.salt = salt;
     }
 
-    public byte[] asBase64() {
-        return Base64.getEncoder().encode(salt);
-    }
-
     public byte[] asBytes() {
         return salt;
     }
 
     @Override
     public String toString() {
-        return new String(asBase64(), StandardCharsets.US_ASCII);
+        // Hex format
+        return String.format("%040x", new BigInteger(1, salt));
     }
 
     @Override

--- a/src/test/java/com/teragrep/jai_02/tests/CachingAndReloadingKeyStoreAccessTest.java
+++ b/src/test/java/com/teragrep/jai_02/tests/CachingAndReloadingKeyStoreAccessTest.java
@@ -86,7 +86,7 @@ public class CachingAndReloadingKeyStoreAccessTest {
     }
 
     @Test
-    public void externalModification_Delete_Test() {
+    public void externalModificationDeleteTest() {
         final CachingKeyStoreAccess readingKeyStoreAccess = new CachingKeyStoreAccess(
                 new ReloadingKeyStoreAccess(
                         new KeyStoreAccessImpl(
@@ -108,7 +108,7 @@ public class CachingAndReloadingKeyStoreAccessTest {
     }
 
     @Test
-    public void externalModification_AddEntry_Test() {
+    public void externalModificationAddEntryTest() {
         // One keyStoreAccess reads the key and one saves it
         // Tests modification of the same keyStore from multiple sources
             Assertions.assertDoesNotThrow(() -> {

--- a/src/test/java/com/teragrep/jai_02/tests/CachingAndReloadingKeyStoreAccessTest.java
+++ b/src/test/java/com/teragrep/jai_02/tests/CachingAndReloadingKeyStoreAccessTest.java
@@ -46,21 +46,14 @@
 
 package com.teragrep.jai_02.tests;
 
-import com.teragrep.jai_02.entry.EntryAliasFactory;
 import com.teragrep.jai_02.keystore.*;
 import com.teragrep.jai_02.password.PasswordEntry;
-import com.teragrep.jai_02.password.PasswordEntryFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import javax.crypto.spec.SecretKeySpec;
-import java.io.IOException;
 import java.nio.file.*;
 import java.security.InvalidKeyException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.UnrecoverableEntryException;
 
 public class CachingAndReloadingKeyStoreAccessTest {
 
@@ -77,8 +70,8 @@ public class CachingAndReloadingKeyStoreAccessTest {
                     new ReloadingKeyStoreAccess(
                             new KeyStoreAccessImpl(
                                     new KeyStoreFactory(keyStorePath, keyStorePassword.toCharArray()).build(),
-                                    keyStorePath, keyStorePassword.toCharArray()), 1L
-                    ), 1L);
+                                    keyStorePath, keyStorePassword.toCharArray()), 0L
+                    ), 0L);
         });
     }
 
@@ -122,7 +115,7 @@ public class CachingAndReloadingKeyStoreAccessTest {
     }
 
     @Test
-    public void externalModification_AddEntry_Test() throws Exception {
+    public void externalModification_AddEntry_Test() {
             Assertions.assertDoesNotThrow(() -> {
                 String user = "new-user";
                 char[] pass = "pass".toCharArray();
@@ -132,17 +125,13 @@ public class CachingAndReloadingKeyStoreAccessTest {
                         new ReloadingKeyStoreAccess(
                                 new KeyStoreAccessImpl(
                                         new KeyStoreFactory(keyStorePath, keyStorePassword.toCharArray()).build(),
-                                        keyStorePath, keyStorePassword.toCharArray()), 1L
-                        ), 1L);
+                                        keyStorePath, keyStorePassword.toCharArray()), 0L
+                        ), 0L);
 
                 cksa2.saveKey(user, pass);
 
-                Thread.sleep(2000);
-
                 PasswordEntry ent1 = cksa.loadKey(user);
-                PasswordEntry ent2 = cksa2.loadKey(user);
-
-                Assertions.assertEquals(ent1.secretKey(), ent2.secretKey());
+                Assertions.assertNotNull(ent1.secretKey());
             });
     }
 }

--- a/src/test/java/com/teragrep/jai_02/tests/KeyStoreAccessImplTest.java
+++ b/src/test/java/com/teragrep/jai_02/tests/KeyStoreAccessImplTest.java
@@ -110,9 +110,11 @@ public class KeyStoreAccessImplTest {
             ksa.deleteKey(userName);
         });
 
-        Assertions.assertThrows(InvalidKeyException.class, () -> {
+        InvalidKeyException ike = Assertions.assertThrows(InvalidKeyException.class, () -> {
             ksa.loadKey(userName);
-        }, "Username <[" + userName + "]> was not found in the map!");
+        }, "LoadKey with username <[" + userName + "]> did not fail as expected, key was found");
+
+        Assertions.assertEquals("Username <[" + userName + "]> was not found in the map!", ike.getMessage());
     }
 
     @Test

--- a/src/test/java/com/teragrep/jai_02/tests/KeyStoreAccessImplTest.java
+++ b/src/test/java/com/teragrep/jai_02/tests/KeyStoreAccessImplTest.java
@@ -116,7 +116,7 @@ public class KeyStoreAccessImplTest {
     }
 
     @Test
-    public void externalModification_AddEntry_Test() {
+    public void externalModificationAddEntryTest() {
         // One keyStoreAccess reads the key and one saves it
         // Tests modification of the same keyStore from multiple sources
         Assertions.assertDoesNotThrow(() -> {
@@ -137,6 +137,7 @@ public class KeyStoreAccessImplTest {
             modifyingKeyStoreAccess.saveKey(user, pass);
 
             Thread.sleep(1500);
+            // Force keyStore file reload
             readingKeyStoreAccess = new KeyStoreAccessImpl(
                     new KeyStoreFactory(keyStorePath, keyStorePassword.toCharArray()).build(),
                     keyStorePath, keyStorePassword.toCharArray());


### PR DESCRIPTION
Fixes the failing test by changing Base64 to Hex encoding, as the KeyStore implementation does not guarantee case sensitivity for aliases.

Also includes:
- Added tests
- Close all Input/OutputStreams
- DecodedHex object
- Invalidates cache on credential delete