### PR TITLE
Add support for username case sensitivity

### DIFF
--- a/src/main/java/com/teragrep/jai_02/entry/EntryAliasString.java
+++ b/src/main/java/com/teragrep/jai_02/entry/EntryAliasString.java
@@ -50,6 +50,8 @@ import com.teragrep.jai_02.password.Salt;
 import com.teragrep.jai_02.user.UserNameImpl;
 import com.teragrep.jai_02.user.UserNameValid;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Provides facilities to generate an EntryAlias object from
  * a compliant String.

--- a/src/main/java/com/teragrep/jai_02/keystore/ReloadingKeyStoreAccess.java
+++ b/src/main/java/com/teragrep/jai_02/keystore/ReloadingKeyStoreAccess.java
@@ -77,7 +77,7 @@ public class ReloadingKeyStoreAccess implements KeyStoreAccess {
         this.loadingCache = CacheBuilder
                 .newBuilder()
                 .maximumSize(1L)
-                .refreshAfterWrite(secs, TimeUnit.SECONDS)
+                .expireAfterWrite(secs, TimeUnit.SECONDS)
                 .build(cacheLoader);
     }
 

--- a/src/main/java/com/teragrep/jai_02/keystore/ReloadingKeyStoreAccess.java
+++ b/src/main/java/com/teragrep/jai_02/keystore/ReloadingKeyStoreAccess.java
@@ -77,7 +77,7 @@ public class ReloadingKeyStoreAccess implements KeyStoreAccess {
         this.loadingCache = CacheBuilder
                 .newBuilder()
                 .maximumSize(1L)
-                .expireAfterWrite(secs, TimeUnit.SECONDS)
+                .refreshAfterWrite(secs, TimeUnit.SECONDS)
                 .build(cacheLoader);
     }
 

--- a/src/main/java/com/teragrep/jai_02/password/DecodedHex.java
+++ b/src/main/java/com/teragrep/jai_02/password/DecodedHex.java
@@ -46,6 +46,7 @@
 package com.teragrep.jai_02.password;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 
 public class DecodedHex {
     private final String hexString;
@@ -64,5 +65,9 @@ public class DecodedHex {
             return output;
         }
         return byteArray;
+    }
+
+    public String decodeString() {
+        return new String(decode(), StandardCharsets.US_ASCII);
     }
 }

--- a/src/main/java/com/teragrep/jai_02/password/EncodedHex.java
+++ b/src/main/java/com/teragrep/jai_02/password/EncodedHex.java
@@ -47,41 +47,14 @@ package com.teragrep.jai_02.password;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
-/**
- * Defines the salt used for salting the SecretKey.
- */
-public class Salt {
-    private final byte[] salt;
-
-    public Salt(byte[] salt) {
-        this.salt = salt;
+public class EncodedHex {
+    private final String nonEncodedString;
+    public EncodedHex(String nonEncodedString) {
+        this.nonEncodedString = nonEncodedString;
     }
 
-    public byte[] asBytes() {
-        return salt;
+    public String encode() {
+        return String.format("%040x", new BigInteger(1, nonEncodedString.getBytes(StandardCharsets.US_ASCII)));
     }
-
-    @Override
-    public String toString() {
-        // Hex format
-        return String.format("%040x", new BigInteger(1, salt));
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        Salt other = (Salt) o;
-        return Arrays.equals(salt, other.asBytes());
-    }
-
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(salt);
-    }
-
 }

--- a/src/main/java/com/teragrep/jai_02/user/UserToAliasMapping.java
+++ b/src/main/java/com/teragrep/jai_02/user/UserToAliasMapping.java
@@ -48,6 +48,7 @@ package com.teragrep.jai_02.user;
 import com.teragrep.jai_02.entry.EntryAlias;
 import com.teragrep.jai_02.entry.EntryAliasString;
 import com.teragrep.jai_02.entry.Split;
+import com.teragrep.jai_02.password.DecodedHex;
 
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -75,9 +76,11 @@ public class UserToAliasMapping {
         }
 
         while (aliases.hasMoreElements()) {
-            final String alias = aliases.nextElement();
-            final EntryAlias k = new EntryAliasString(alias, split).toEntryAlias();
-            this.internalMap.put(k.userName().toString(), alias);
+            final String originalAlias = aliases.nextElement();
+            final String decodedAlias = new DecodedHex(originalAlias).decodeString();
+
+            final EntryAlias k = new EntryAliasString(decodedAlias, split).toEntryAlias();
+            this.internalMap.put(k.userName().toString(), originalAlias);
         }
     }
 

--- a/src/test/java/com/teragrep/jai_02/tests/KeyStoreAccessImplTest.java
+++ b/src/test/java/com/teragrep/jai_02/tests/KeyStoreAccessImplTest.java
@@ -135,6 +135,12 @@ public class KeyStoreAccessImplTest {
         });
 
         Assertions.assertEquals("Username <[" + user1 + "]> was not found in the map!", ike.getMessage());
+
+        // Make sure that user0 can be loaded
+        Assertions.assertDoesNotThrow(() -> {
+            PasswordEntry pe = ksa.loadKey(user0);
+            Assertions.assertEquals(user0, pe.entryAlias().userName().toString());
+        });
     }
 
     @Test

--- a/src/test/java/com/teragrep/jai_02/tests/KeyStoreAccessImplTest.java
+++ b/src/test/java/com/teragrep/jai_02/tests/KeyStoreAccessImplTest.java
@@ -118,6 +118,26 @@ public class KeyStoreAccessImplTest {
     }
 
     @Test
+    public void usernameCaseSensitivityTest() {
+        String user0 = "userNAME";
+        String user1 = "username";
+        // Make sure existing entries do not exist by deleting them
+        // Save user0 to KeyStore
+        Assertions.assertDoesNotThrow(() -> {
+            ksa.deleteKey(user0);
+            ksa.deleteKey(user1);
+            ksa.saveKey(user0, "password".toCharArray());
+        });
+
+        // Try loading user1 from KeyStore, should fail as they are in different cases
+        InvalidKeyException ike = Assertions.assertThrows(InvalidKeyException.class, () -> {
+            ksa.loadKey(user1);
+        });
+
+        Assertions.assertEquals("Username <[" + user1 + "]> was not found in the map!", ike.getMessage());
+    }
+
+    @Test
     public void externalModificationAddEntryTest() {
         // One keyStoreAccess reads the key and one saves it
         // Tests modification of the same keyStore from multiple sources


### PR DESCRIPTION
Hex encodes the whole EntryAlias to preserve case sensitivity as entries from KeyStore are returned as all lowercase.